### PR TITLE
Remove overflow: hidden to avoid items being cutoff when itemWidth is…

### DIFF
--- a/src/components/PageItem.tsx
+++ b/src/components/PageItem.tsx
@@ -105,7 +105,6 @@ export default function PageItem<TData = any>({
       style={[
         {
           width: itemWidth,
-          overflow: 'hidden',
         },
         containerStyle,
       ]}


### PR DESCRIPTION
Remove overflow: hidden to avoid items being cutoff when itemWidth is less than the actual size of the content